### PR TITLE
Fix adc in hwlib

### DIFF
--- a/library/targets/hwlib-arduino-due.hpp
+++ b/library/targets/hwlib-arduino-due.hpp
@@ -892,6 +892,13 @@ public:
       // return the conversion result
       return ADC->ADC_CDR[ channel ] & 0x0000'0FFF;
    }
+   /// refresh adc reading
+   ///
+   /// This function needs to be here since it's parent has a refresh virtual function.
+   /// The adc implementation seems to work without this function
+   void refresh(){
+
+   }
 };
 
 /// the number of ticks per us

--- a/library/targets/hwlib-arduino-due.hpp
+++ b/library/targets/hwlib-arduino-due.hpp
@@ -895,7 +895,7 @@ public:
    /// refresh adc reading
    ///
    /// This function needs to be here since it's parent has a refresh virtual function.
-   /// The adc implementation seems to work without this function
+   /// The adc implementation seems to work with an empty function
    void refresh(){
 
    }


### PR DESCRIPTION
By default hwlib has a non functional adc converter class, by adding the empty refresh function adc seems to work.